### PR TITLE
Update package to support new libp2p Transports/Upgraders

### DIFF
--- a/onion_transport.go
+++ b/onion_transport.go
@@ -129,9 +129,10 @@ func (t *OnionTransport) Protocols() []int {
 	return protocols
 }
 
-// Proxy returns true, for tor is a relay-based protocol.
+// Proxy returns false since, for the time being, tor connections can't be
+// composed with other transports.
 func (t *OnionTransport) Proxy() bool {
-	return true
+	return false
 }
 
 // NewOnionTransport creates a OnionTransport

--- a/onion_transport.go
+++ b/onion_transport.go
@@ -150,6 +150,18 @@ func NewOnionTransport(controlNet, controlAddr, controlPass string, auth *proxy.
 	return &o, nil
 }
 
+// OnionTransportC is a type alias for OnionTransport constructors, for use
+// with libp2p.New
+type OnionTransportC func(*tptu.Upgrader) (tpt.Transport, error)
+
+// NewOnionTransportC is a convenience function that returns a function
+// suitable for passing into libp2p.Transport for host configuration
+func NewOnionTransportC(controlNet, controlAddr, controlPass string, auth *proxy.Auth, keysDir string, onlyOnion bool) OnionTransportC {
+	return func(upgrader *tptu.Upgrader) (tpt.Transport, error) {
+		return NewOnionTransport(controlNet, controlAddr, controlPass, auth, keysDir, upgrader, onlyOnion)
+	}
+}
+
 // TorDialer returns a proxy dialer gathered from the control interface.
 // This isn't needed for the IPFS transport but it provides
 // easy access to Tor for other functions.

--- a/onion_transport_test.go
+++ b/onion_transport_test.go
@@ -1,14 +1,15 @@
 package torOnion
 
 import (
-	"testing"
-	ma "github.com/multiformats/go-multiaddr"
-	"crypto/rsa"
-	"github.com/yawning/bulb/utils/pkcs1"
-	"os"
-	"encoding/pem"
 	"crypto/rand"
+	"crypto/rsa"
+	"encoding/pem"
+	"os"
 	"path"
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/yawning/bulb/utils/pkcs1"
 )
 
 var key string
@@ -25,7 +26,7 @@ func setup() {
 }
 
 func teardown() {
-	os.RemoveAll(path.Join("./", key + ".onion_key"))
+	os.RemoveAll(path.Join("./", key+".onion_key"))
 }
 
 func TestIsValidOnionMultiAddr(t *testing.T) {
@@ -51,7 +52,7 @@ func TestIsValidOnionMultiAddr(t *testing.T) {
 }
 
 func Test_loadKeys(t *testing.T) {
-	tpt := &OnionTransport{keysDir:"./"}
+	tpt := &OnionTransport{keysDir: "./"}
 	keys, err := tpt.loadKeys()
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +71,7 @@ func Test_loadKeys(t *testing.T) {
 	}
 }
 
-func createHiddenServiceKey() (string, error){
+func createHiddenServiceKey() (string, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		return "", err
@@ -80,7 +81,7 @@ func createHiddenServiceKey() (string, error){
 		return "", err
 	}
 
-	f, err := os.Create(id+".onion_key")
+	f, err := os.Create(id + ".onion_key")
 	if err != nil {
 		return "", err
 	}

--- a/package.json
+++ b/package.json
@@ -5,34 +5,34 @@
   },
   "gxDependencies": [
     {
-      "author": "multiformats",
-      "hash": "QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji",
-      "name": "go-multiaddr",
-      "version": "1.2.4"
-    },
-    {
-      "author": "multiformats",
-      "hash": "QmX3U3YXCQ6UYBxq2LVWF8dARS1hPUTEYLrSx654Qyxyw6",
-      "name": "go-multiaddr-net",
-      "version": "1.5.5"
-    },
-    {
       "author": "whyrusleeping",
-      "hash": "QmYcK2kPkJmj9GMxKvLhD4REtAkeuaN8sqDEJePmEqHQnp",
-      "name": "go-libp2p-transport",
-      "version": "3.0.0"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmZQa5J7j7kd44GGC4aKX8J9JGGzCMqwGzcEFqGV1YD57A",
+      "hash": "QmYrE8ETPuzJYQuAbPwH512wcpvATJ9vK75jUz2twKdHMo",
       "name": "mafmt",
-      "version": "1.2.3"
+      "version": "1.2.6"
     },
     {
-      "author": "Yawning Angel",
-      "hash": "QmdDmJub1b5qyQSGfVZW5HcQx1BSjQU3uRbaZtT3Z1GDMj",
+      "author": "multiformats",
+      "hash": "QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7",
+      "name": "go-multiaddr",
+      "version": "1.3.0"
+    },
+    {
+      "author": "multiformats",
+      "hash": "QmcGpxjg5xP5Jqni5hosEz3dGJuNDKvC4J49qqvfxBBHuk",
+      "name": "go-multiaddr-net",
+      "version": "1.6.2"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmVMBFZqRZDA6TrQkVGGJEDSp5jC3UUMUjLcvaZ3fLCqh4",
+      "name": "go-libp2p-transport",
+      "version": "3.0.2"
+    },
+    {
+      "author": "Yawning",
+      "hash": "Qmc5fpApVsws2jdrkkr4yCdKsQ7AFHYZSmqkWWk1mW2jCL",
       "name": "bulb",
-      "version": "0.1.0"
+      "version": "1.0.0"
     }
   ],
   "gxVersion": "0.11.0",


### PR DESCRIPTION
This PR brings this package up to date with the latest APIs for go-libp2p. The transport, listener, and dialer behaviors have been updated to reflect the new interfaces and a potential information leak (via exposing onion addresses) has been shored up.